### PR TITLE
refactor: Update example proposal template to insert reusable table

### DIFF
--- a/method-proposals/PROPOSAL-did-example.md
+++ b/method-proposals/PROPOSAL-did-example.md
@@ -14,6 +14,44 @@ Document here any existing draft specifications, implementations, deployments, t
 
 Document here how this DID method meets the [DID method selection criteria](../selection-criteria/).
 
+| **Criteria** | **Details** |
+|----------|----------|
+| **Alignment with DID Core specification** | Lorem ipsum... |
+| **Security and privacy features** | Lorem ipsum... |
+| **Scalability and performance** | Lorem ipsum... |
+| **Ease of implementation and use** | Lorem ipsum... |
+| **Community adoption and support** | Lorem ipsum... |
+| **Compliance with relevant regulations and best practices** | Lorem ipsum... |
+| **Global government-approved crypto** | Lorem ipsum... |
+| **Privacy-preserving crypto** | Lorem ipsum... |
+| **Digitally signed cryptographic log of changes to the DID Document** | Lorem ipsum... |
+| **Multi-factor binding to DNS** | Lorem ipsum... |
+| **Specification with multiple implementers** | Lorem ipsum... |
+| **Scope/domain of the types of entities/subjects addressed/named by a particular method** | Lorem ipsum... |
+| **Estimate of the daily transaction volume of each scope/domain** | Lorem ipsum... |
+| **DID Methods that do not serve the needs of a particular company or government** | Lorem ipsum... |
+| **Governance: Clear frameworks for updates, dispute resolution, and decision-making** | Lorem ipsum... |
+| **Usability: Simple implementation for developers** | Lorem ipsum... |
+| **Sustainability: Energy efficiency and eco-friendly infrastructure** | Lorem ipsum... |
+| **Economic Feasibility: DIDs costs of use must be reasonable** | Lorem ipsum... |
+| **Legal Recognition: Cross-border frameworks for DID acceptance** | Lorem ipsum... |
+| **Revocation and Recovery: Decentralized mechanisms for key rotation and DID recovery** | Lorem ipsum... |
+| **Emerging Markets: Offline-friendly, low-bandwidth** | Lorem ipsum... |
+| **Long-lived DIDs needed for long-lived VCs** | Lorem ipsum... |
+| **Low and predictable marginal cost at scale (millions of accounts)** | Lorem ipsum... |
+| **Ability to create and update identifiers rapidly (within seconds)** | Lorem ipsum... |
+| **Support for key rotation** | Lorem ipsum... |
+| **Reliable and predictable-latency operation, for updating and resolving** | Lorem ipsum... |
+| **Resolution should not require additional state or context** | Lorem ipsum... |
+| **DIDs are permanent and immutable account identifiers** | Yes. |
+| **Consider support for various DID Traits: https://identity.foundation/did-traits/** | Lorem ipsum...  |
+| **Consider categories defined by DID Rubric: https://www.w3.org/TR/did-rubric/** | Lorem ipsum... |
+| **Who WANTS to standardize the DID method and commits to doing the work?** | Lorem ipsum... |
+| **Are there AT LEAST two WG members who support standardization of a DID method?** | LLorem ipsum... |
+| **Are there no trademark or IP issues?** | Lorem ipsum... |
+| **Diversity of the set of selected DID methods** | Lorem ipsum... |
+| **What type of DID method is this?** | Ephemeral / Web-based / Decentralized |
+
 ## Supporting use cases
 
 Document here how this DID method supports concrete use cases.

--- a/method-proposals/PROPOSAL-did-example.md
+++ b/method-proposals/PROPOSAL-did-example.md
@@ -50,7 +50,7 @@ Document here how this DID method meets the [DID method selection criteria](../s
 | **Are there AT LEAST two WG members who support standardization of a DID method?** | LLorem ipsum... |
 | **Are there no trademark or IP issues?** | Lorem ipsum... |
 | **Diversity of the set of selected DID methods** | Lorem ipsum... |
-| **What type of DID method is this?** | Ephemeral / Web-based / Decentralized |
+| **What type of DID method is this?** | Ephemeral / Web-based / Decentralized / Other (please choose one/specify) |
 
 ## Supporting use cases
 


### PR DESCRIPTION
I've refactored the example proposal template file as discussed during the WG meeting yesterday to:

1. Add a table that people can populate
2. Instead of three separate statements/rows "At least one ephemeral/web-based/decentralized method", I've turned this into a question so that people can pick between those choices.