### PR TITLE
style: Refactor proposals to two-column tables for better readability

### DIFF
--- a/method-proposals/PROPOSAL-did-example.md
+++ b/method-proposals/PROPOSAL-did-example.md
@@ -49,7 +49,6 @@ Document here how this DID method meets the [DID method selection criteria](../s
 | **Who WANTS to standardize the DID method and commits to doing the work?** | Lorem ipsum... |
 | **Are there AT LEAST two WG members who support standardization of a DID method?** | LLorem ipsum... |
 | **Are there no trademark or IP issues?** | Lorem ipsum... |
-| **Diversity of the set of selected DID methods** | Lorem ipsum... |
 | **What type of DID method is this?** | Ephemeral / Web-based / Decentralized / Other (please choose one/specify) |
 
 ## Supporting use cases

--- a/method-proposals/PROPOSAL-did-key.md
+++ b/method-proposals/PROPOSAL-did-key.md
@@ -36,82 +36,45 @@ support key revocation or key rotation. As of January 2025, it is implemented by
 
 Document here how this DID method meets the [DID method selection criteria](../selection-criteria/).
 
-| **Criteria** |
-| -------- |
-| **Alignment with DID Core specification** |
-| Yes, fully compliant with DID specification. |
-| **Security and privacy features** |
-| INEFFECTIVE CRITERIA: Every DID Method will probably state: Yes, has security and privacy features. |
-| **Scalability and performance** |
-| Good scalability performance. Limits are based on CPU and memory performance (ECDSA generation: ~1,000 keys per second per core) |
-| **Ease of implementation and use** |
-| Relatively easy to implement and use. Development effort for a single developer creating an initial implementation is between 1-3 days. A complete production-ready implementation might take 2-3 weeks. |
-| **Community adoption and support** |
-| Implemented by at least 23 independent software systems. |
-| **Compliance with relevant regulations and best practices** |
-| INEFFECTIVE CRITERIA: Every DID Method will probably state: Yes, for the regulations and best practices that apply. |
-| **Global government-approved crypto** |
-| Uses latest approved NIST and FIPS cryptography (ECDSA and EdDSA) used by many Western nation states with ability to support other Eastern nation-state backed government cryptography. |
-| **Privacy-preserving crypto** |
-| Yes, supports BBS privacy-preserving cryptographic key formats. |
-| **Digitally signed cryptographic log of changes to the DID Document** |
-| No. |
-| **Multi-factor binding to DNS** |
-| No. |
-| **Specification with multiple implementers** |
-| Yes, although the specification needs further work and updating. |
-| **Scope/domain of the types of entities/subjects addressed/named by a particular method** |
-| INEFFECTIVE CRITERIA: Debatably, this seems like a privacy-harming anti-pattern to claim that specific types of entities require specific types of DIDs. |
-| **Estimate of the daily transaction volume of each scope/domain** |
-| INEFFECTIVE CRITERIA: Debatably, this seems like a privacy harming anti-pattern to be able to count transaction volume of DID usage. Estimating seems fraught as well without hard data. Getting these sorts of counts in decentralized systems is difficult. |
-| **DID Methods that do not serve the needs of a particular company or government** |
-| INEFFECTIVE CRITERIA: What "do not serve" means is unclear. |
-| **Governance: Clear frameworks for updates, dispute resolution, and decision-making** |
-| No framework is needed since updates are not supported, disputes could only be about private key possession (and a court with jurisdiction would adjudicate any dispute, and any other decision making does not apply. |
-| **Usability: Simple implementation for developers** |
-| Yes, as evidenced by the number of implementations and positive developer feedback. |
-| **Sustainability: Energy efficiency and eco-friendly infrastructure** |
-| Yes, keys take milliseconds to create and a few hundred bytes to store. |
-| **Economic Feasibility: DIDs costs of use must be reasonable** |
-| Yes, costs are a fraction of the smallest denomination of mainstream currencies (less than $0.0000004 USD for an ECDSA create operation). |
-| **Legal Recognition: Cross-border frameworks for DID acceptance** |
-| Yes, supports key types approved by multiple national governments. |
-| **Revocation and Recovery: Decentralized mechanisms for key rotation and DID recovery** |
-| None. |
-| **Emerging Markets: Offline-friendly, low-bandwidth** |
-| Yes, offline-friendly due to no need for a network look up. |
-| **Long-lived DIDs needed for long-lived VCs** |
-| Yes, but only if paired with hardware security modules. |
-| **Low and predictable marginal cost at scale (millions of accounts)** |
-| Yes. |
-| **Ability to create and update identifiers rapidly (within seconds)** |
-| Yes, within milliseconds for creation. Update is not supported. |
-| **Support for key rotation** |
-| No. |
-| **Reliable and predictable-latency operation, for updating and resolving** |
-| Yes. |
-| **Resolution should not require additional state or context** |
-| Yes. |
-| **DIDs are permanent and immutable account identifiers** |
-| Yes. |
-| **Consider support for various DID Traits: https://identity.foundation/did-traits/** |
-| BAD CRITERIA: Traits should be listed directly. |
-| **Consider categories defined by DID Rubric: https://www.w3.org/TR/did-rubric/** |
-| BAD CRITERIA: Rubric categories should be listed directly. |
-| **Who WANTS to standardize the DID method and commits to doing the work?** |
-| Digital Bazaar will commit to doing the work through the entire standardization process. |
-| **Are there AT LEAST two WG members who support standardization of a DID method?** |
-| TBD. |
-| **Are there no trademark or IP issues?** |
-| None. |
-| **Diversity of the set of selected DID methods** |
-| BAD CRITERIA: Should be removed as this is a meta-question about the set of selected methods. |
-| **At least one ephemeral DID method** |
-| This could be considered one of the ephemeral DID Methods. |
-| **At least one web-based DID method** |
-| This is not a web-based DID Method. |
-| **At least one fully decentralized DID method** |
-| While it is debatable that this is a fully decentralized DID Method, the lack of update and deactivate features probably disqualify it from what people typically mean by "fully decentralized". |
+| **Criteria** | **Details** |
+|----------|----------|
+| **Alignment with DID Core specification** | Yes, fully compliant with DID specification. |
+| **Security and privacy features** | INEFFECTIVE CRITERIA: Every DID Method will probably state: Yes, has security and privacy features. |
+| **Scalability and performance** | Good scalability performance. Limits are based on CPU and memory performance (ECDSA generation: ~1,000 keys per second per core) |
+| **Ease of implementation and use** | Relatively easy to implement and use. Development effort for a single developer creating an initial implementation is between 1-3 days. A complete production-ready implementation might take 2-3 weeks. |
+| **Community adoption and support** | Implemented by at least 23 independent software systems. |
+| **Compliance with relevant regulations and best practices** | INEFFECTIVE CRITERIA: Every DID Method will probably state: Yes, for the regulations and best practices that apply. |
+| **Global government-approved crypto** | Uses latest approved NIST and FIPS cryptography (ECDSA and EdDSA) used by many Western nation states with ability to support other Eastern nation-state backed government cryptography. |
+| **Privacy-preserving crypto** | Yes, supports BBS privacy-preserving cryptographic key formats. |
+| **Digitally signed cryptographic log of changes to the DID Document** | No. |
+| **Multi-factor binding to DNS** | No. |
+| **Specification with multiple implementers** | Yes, although the specification needs further work and updating. |
+| **Scope/domain of the types of entities/subjects addressed/named by a particular method** | INEFFECTIVE CRITERIA: Debatably, this seems like a privacy-harming anti-pattern to claim that specific types of entities require specific types of DIDs. |
+| **Estimate of the daily transaction volume of each scope/domain** | INEFFECTIVE CRITERIA: Debatably, this seems like a privacy harming anti-pattern to be able to count transaction volume of DID usage. Estimating seems fraught as well without hard data. Getting these sorts of counts in decentralized systems is difficult. |
+| **DID Methods that do not serve the needs of a particular company or government** | INEFFECTIVE CRITERIA: What "do not serve" means is unclear. |
+| **Governance: Clear frameworks for updates, dispute resolution, and decision-making** | No framework is needed since updates are not supported, disputes could only be about private key possession (and a court with jurisdiction would adjudicate any dispute, and any other decision making does not apply. |
+| **Usability: Simple implementation for developers** | Yes, as evidenced by the number of implementations and positive developer feedback. |
+| **Sustainability: Energy efficiency and eco-friendly infrastructure** | Yes, keys take milliseconds to create and a few hundred bytes to store. |
+| **Economic Feasibility: DIDs costs of use must be reasonable** | Yes, costs are a fraction of the smallest denomination of mainstream currencies (less than $0.0000004 USD for an ECDSA create operation). |
+| **Legal Recognition: Cross-border frameworks for DID acceptance** | Yes, supports key types approved by multiple national governments. |
+| **Revocation and Recovery: Decentralized mechanisms for key rotation and DID recovery** | None. |
+| **Emerging Markets: Offline-friendly, low-bandwidth** | Yes, offline-friendly due to no need for a network look up. |
+| **Long-lived DIDs needed for long-lived VCs** | Yes, but only if paired with hardware security modules. |
+| **Low and predictable marginal cost at scale (millions of accounts)** | Yes. |
+| **Ability to create and update identifiers rapidly (within seconds)** | Yes, within milliseconds for creation. Update is not supported. |
+| **Support for key rotation** | No. |
+| **Reliable and predictable-latency operation, for updating and resolving** | Yes. |
+| **Resolution should not require additional state or context** | Yes. |
+| **DIDs are permanent and immutable account identifiers** | Yes. |
+| **Consider support for various DID Traits: https://identity.foundation/did-traits/** | BAD CRITERIA: Traits should be listed directly. |
+| **Consider categories defined by DID Rubric: https://www.w3.org/TR/did-rubric/** | BAD CRITERIA: Rubric categories should be listed directly. |
+| **Who WANTS to standardize the DID method and commits to doing the work?** | Digital Bazaar will commit to doing the work through the entire standardization process. |
+| **Are there AT LEAST two WG members who support standardization of a DID method?** | TBD. |
+| **Are there no trademark or IP issues?** | None. |
+| **Diversity of the set of selected DID methods** | BAD CRITERIA: Should be removed as this is a meta-question about the set of selected methods. |
+| **At least one ephemeral DID method** | This could be considered one of the ephemeral DID Methods. |
+| **At least one web-based DID method** | This is not a web-based DID Method. |
+| **At least one fully decentralized DID method** | While it is debatable that this is a fully decentralized DID Method, the lack of update and deactivate features probably disqualify it from what people typically mean by "fully decentralized". |
 
 ## Supporting use cases
 

--- a/method-proposals/PROPOSAL-did-key.md
+++ b/method-proposals/PROPOSAL-did-key.md
@@ -71,10 +71,7 @@ Document here how this DID method meets the [DID method selection criteria](../s
 | **Who WANTS to standardize the DID method and commits to doing the work?** | Digital Bazaar will commit to doing the work through the entire standardization process. |
 | **Are there AT LEAST two WG members who support standardization of a DID method?** | TBD. |
 | **Are there no trademark or IP issues?** | None. |
-| **Diversity of the set of selected DID methods** | BAD CRITERIA: Should be removed as this is a meta-question about the set of selected methods. |
-| **At least one ephemeral DID method** | This could be considered one of the ephemeral DID Methods. |
-| **At least one web-based DID method** | This is not a web-based DID Method. |
-| **At least one fully decentralized DID method** | While it is debatable that this is a fully decentralized DID Method, the lack of update and deactivate features probably disqualify it from what people typically mean by "fully decentralized". |
+| **What type of DID method is this?** | Ephemeral. While it is debatable that this is a fully decentralized DID Method, the lack of update and deactivate features probably disqualify it from what people typically mean by "fully decentralized". |
 
 ## Supporting use cases
 

--- a/method-proposals/PROPOSAL-did-scid.md
+++ b/method-proposals/PROPOSAL-did-scid.md
@@ -47,10 +47,7 @@ The `did:scid` method is designed to maximize the security, privacy, and portabi
 | **Who WANTS to standardize the DID method and commits to doing the work?** | Trust-Over-IP. |
 | **Are there AT LEAST two WG members who support standardization of a DID method?** | Yes. |
 | **Are there no trademark or IP issues?** | None. |
-| **Diversity of the set of selected DID methods** | n/a |
-| **At least one ephemeral DID method** | Yes. |
-| **At least one web-based DID method** | Yes. |
-| **At least one fully decentralized DID method** | Yes. |
+| **What type of DID method is this?** | Other. Based on the underlying method used to refer to verification material. |
 
 ## Supporting use cases
 

--- a/method-proposals/PROPOSAL-did-scid.md
+++ b/method-proposals/PROPOSAL-did-scid.md
@@ -4,7 +4,7 @@ This is a proposal to include `did:scid` in the initial set of DID methods that 
 
 ## Description
 
-The `did:scid` method is designed to maximize the security, privacy, and portability benefits of self-certifying identifiers (SCIDs) independent of the specific type of SCID. It potentially augments a number of existing DID methods such as `did:webvh`, `did:webs`, and `did:peer` by specifying the location of the verification metatdata in the identifier.
+The `did:scid` method is designed to maximize the security, privacy, and portability benefits of self-certifying identifiers (SCIDs) independent of the specific type of SCID. It potentially augments a number of existing DID methods such as `did:webvh`, `did:webs`, and `did:peer` by specifying the location of the verification metatdata as a URI query parameter.
 
 ## Existing materials
 

--- a/method-proposals/PROPOSAL-did-scid.md
+++ b/method-proposals/PROPOSAL-did-scid.md
@@ -12,82 +12,45 @@ The `did:scid` method is designed to maximize the security, privacy, and portabi
 
 ## Meeting the selection criteria
 
-| **Criteria** |
-| -------- |
-| **Alignment with DID Core specification** |
-| Fully compliant with core spec. |
-| **Security and privacy features** |
-| High privacy and security are possible depending on the underlying method represented by the `did:scid`. |
-| **Scalability and performance** |
-| Can be very scalable and performant depending on the underlying method. |
-| **Ease of implementation and use** |
-| Variable. It depends on the underlying method. |
-| **Community adoption and support** |
-| Adoption and support varies, but is generally wide. Examples of underlying methods include `did:webvh`, `did:webs`, `did:peer`, and `did:jlinc`|
-| **Compliance with relevant regulations and best practices** |
-| Generally highly compliant.|
-| **Global government-approved crypto** |
-| Yes. |
-| **Privacy-preserving crypto** |
-| Yes. |
-| **Digitally signed cryptographic log of changes to the DID Document** |
-| Yes. |
-| **Multi-factor binding to DNS** |
-| Unkown. |
-| **Specification with multiple implementers** |
-| Dependent on underlying method. |
-| **Scope/domain of the types of entities/subjects addressed/named by a particular method** |
-| Wide. |
-| **Estimate of the daily transaction volume of each scope/domain** |
-| Unkown. |
-| **DID Methods that do not serve the needs of a particular company or government** |
-| Does not. |
-| **Governance: Clear frameworks for updates, dispute resolution, and decision-making** |
-| Yes. The current standardization body is Trust-Over-IP (TOIP) |
-| **Usability: Simple implementation for developers** |
-| Depends on underlying method. |
-| **Sustainability: Energy efficiency and eco-friendly infrastructure** |
-| Unkown. |
-| **Economic Feasibility: DIDs costs of use must be reasonable** |
-| Unknown. |
-| **Legal Recognition: Cross-border frameworks for DID acceptance** |
-| Presumably good. |
-| **Revocation and Recovery: Decentralized mechanisms for key rotation and DID recovery** |
-| Absolutely. |
-| **Emerging Markets: Offline-friendly, low-bandwidth** |
-| Yes. |
-| **Long-lived DIDs needed for long-lived VCs** |
-| Yes. |
-| **Low and predictable marginal cost at scale (millions of accounts)** |
-| Unkown. |
-| **Ability to create and update identifiers rapidly (within seconds)** |
-| Yes. |
-| **Support for key rotation** |
-| Yes. |
-| **Reliable and predictable-latency operation, for updating and resolving** |
-| Yes. |
-| **Resolution should not require additional state or context** |
-| Yes. |
-| **DIDs are permanent and immutable account identifiers** |
-| Unsure |
-| **Consider support for various DID Traits: https://identity.foundation/did-traits/** |
-| Updateable, Updateable Service Endpoints, Deactivatable, Deletable, Self-Certifying, Rotatable Verification Methods, Pre-rotation of Keys, Multi-Signature Verification Method, Globally Resolvable, Centrally Hosted, United States of America NIST-approved Cryptography |
-| **Consider categories defined by DID Rubric: https://www.w3.org/TR/did-rubric/** |
-| Not evaluated. |
-| **Who WANTS to standardize the DID method and commits to doing the work?** |
-| Trust-Over-IP. |
-| **Are there AT LEAST two WG members who support standardization of a DID method?** |
-| Yes. |
-| **Are there no trademark or IP issues?** |
-| None. |
-| **Diversity of the set of selected DID methods** |
-| n/a |
-| **At least one ephemeral DID method** |
-| Yes. |
-| **At least one web-based DID method** |
-| Yes. |
-| **At least one fully decentralized DID method** |
-| Yes. |
+| **Criteria** | **Details** |
+|----------|----------|
+| **Alignment with DID Core specification** | Fully compliant with core spec. |
+| **Security and privacy features** | High privacy and security are possible depending on the underlying method represented by the `did:scid`. |
+| **Scalability and performance** | Can be very scalable and performant depending on the underlying method. |
+| **Ease of implementation and use** | Variable. It depends on the underlying method. |
+| **Community adoption and support** | Adoption and support varies, but is generally wide. Examples of underlying methods include `did:webvh`, `did:webs`, `did:peer`, and `did:jlinc`|
+| **Compliance with relevant regulations and best practices** | Generally highly compliant.|
+| **Global government-approved crypto** | Yes. |
+| **Privacy-preserving crypto** | Yes. |
+| **Digitally signed cryptographic log of changes to the DID Document** | Yes. |
+| **Multi-factor binding to DNS** | Unknown. |
+| **Specification with multiple implementers** | Dependent on underlying method. |
+| **Scope/domain of the types of entities/subjects addressed/named by a particular method** | Wide. |
+| **Estimate of the daily transaction volume of each scope/domain** | Unknown. |
+| **DID Methods that do not serve the needs of a particular company or government** | Does not. |
+| **Governance: Clear frameworks for updates, dispute resolution, and decision-making** | Yes. The current standardization body is Trust-Over-IP (TOIP) |
+| **Usability: Simple implementation for developers** | Depends on underlying method. |
+| **Sustainability: Energy efficiency and eco-friendly infrastructure** | Unknown. |
+| **Economic Feasibility: DIDs costs of use must be reasonable** | Unknown. |
+| **Legal Recognition: Cross-border frameworks for DID acceptance** | Presumably good. |
+| **Revocation and Recovery: Decentralized mechanisms for key rotation and DID recovery** | Absolutely. |
+| **Emerging Markets: Offline-friendly, low-bandwidth** | Yes. |
+| **Long-lived DIDs needed for long-lived VCs** | Yes. |
+| **Low and predictable marginal cost at scale (millions of accounts)** | Unknown. |
+| **Ability to create and update identifiers rapidly (within seconds)** | Yes. |
+| **Support for key rotation** | Yes. |
+| **Reliable and predictable-latency operation, for updating and resolving** | Yes. |
+| **Resolution should not require additional state or context** | Yes. |
+| **DIDs are permanent and immutable account identifiers** | Unsure |
+| **Consider support for various DID Traits: https://identity.foundation/did-traits/** | Updateable, Updateable Service Endpoints, Deactivatable, Deletable, Self-Certifying, Rotatable Verification Methods, Pre-rotation of Keys, Multi-Signature Verification Method, Globally Resolvable, Centrally Hosted, United States of America NIST-approved Cryptography |
+| **Consider categories defined by DID Rubric: https://www.w3.org/TR/did-rubric/** | Not evaluated. |
+| **Who WANTS to standardize the DID method and commits to doing the work?** | Trust-Over-IP. |
+| **Are there AT LEAST two WG members who support standardization of a DID method?** | Yes. |
+| **Are there no trademark or IP issues?** | None. |
+| **Diversity of the set of selected DID methods** | n/a |
+| **At least one ephemeral DID method** | Yes. |
+| **At least one web-based DID method** | Yes. |
+| **At least one fully decentralized DID method** | Yes. |
 
 ## Supporting use cases
 

--- a/method-proposals/PROPOSAL-did-web.md
+++ b/method-proposals/PROPOSAL-did-web.md
@@ -80,10 +80,7 @@ Document here how this DID method meets the [DID method selection criteria](../s
 | **Who WANTS to standardize the DID method and commits to doing the work?** | Digital Bazaar will commit to doing the base spec work through the entire standardization process but will rely on other teams, such as `did:webvh` to add additional features. |
 | **Are there AT LEAST two WG members who support standardization of a DID method?** | Yes, Digital Bazaar and Province of BC. |
 | **Are there no trademark or IP issues?** | None. |
-| **Diversity of the set of selected DID methods** | BAD CRITERIA: Should be removed as this is a meta-question about the set of selected methods. |
-| **At least one ephemeral DID method** | This is not an ephemeral DID Method. |
-| **At least one web-based DID method** | This could be considered one of the Web-based DID Methods. |
-| **At least one fully decentralized DID method** | While it is debatable that this is a fully decentralized DID Method, the reliance on DNS and the centralized hosting on a website probably disqualifies it from what people typically mean by "fully decentralized". |
+| **What type of DID method is this?** | Web-based.  While it is debatable that this is a fully decentralized DID Method, the reliance on DNS and the centralized hosting on a website probably disqualifies it from what people typically mean by "fully decentralized". |
 
 ## Supporting use cases
 

--- a/method-proposals/PROPOSAL-did-web.md
+++ b/method-proposals/PROPOSAL-did-web.md
@@ -45,82 +45,45 @@ extensions are being created for it.
 
 Document here how this DID method meets the [DID method selection criteria](../selection-criteria/).
 
-| **Criteria** |
-| -------- |
-| **Alignment with DID Core specification** |
-| Yes, fully compliant with DID specification. |
-| **Security and privacy features** |
-| INEFFECTIVE CRITERIA: Every DID Method will probably state: Yes, has security and privacy features. |
-| **Scalability and performance** |
-| Good scalability. Limits are tied to CPU and memory speeds (ECDSA generation: ~1,000 keys per second per core) |
-| **Ease of implementation and use** |
-| Relatively easy to implement and use. Development effort for a single developer creating an initial implementation is one to three days. A complete production-ready implementation might take two to three weeks. |
-| **Community adoption and support** |
-| Implemented by at least six independent software systems. |
-| **Compliance with relevant regulations and best practices** |
-| INEFFECTIVE CRITERIA: Every DID Method will probably state: Yes, for the regulations and best practices that apply. |
-| **Global government-approved crypto** |
-| Uses latest approved NIST and FIPS cryptography (ECDSA and EdDSA) used by many Western nation-states with ability to support cryptography backed by other Eastern nation-state governments. |
-| **Privacy-preserving crypto** |
-| Yes, supports BBS privacy-preserving cryptographic key formats. |
-| **Digitally signed cryptographic log of changes to the DID Document** |
-| No. |
-| **Multi-factor binding to DNS** |
-| No. |
-| **Specification with multiple implementers** |
-| Yes, although the specification needs further work and updating. |
-| **Scope/domain of the types of entities/subjects addressed/named by a particular method** |
-| INEFFECTIVE CRITERIA: Debatably. Claiming that specific types of entities require specific types of DIDs seems like a privacy-harming anti-pattern. |
-| **Estimate of the daily transaction volume of each scope/domain** |
-| INEFFECTIVE CRITERIA: Debatably. Being able to count transaction volume of DID usage seems like a privacy harming anti-pattern. Estimating without hard data seems fraught as well. It is difficult to get these sorts of counts from decentralized systems. |
-| **DID Methods that do not serve the needs of a particular company or government** |
-| INEFFECTIVE CRITERIA: The meaning of "do not serve" is unclear. |
-| **Governance: Clear frameworks for updates, dispute resolution, and decision-making** |
-| Framework for updates and dispute resolution is based on the domain hosting the document. Disputes regarding domain names are processed through IANA's [dispute resolution procedures](https://www.icann.org/resources/pages/help/dndr/udrp-en). |
-| **Usability: Simple implementation for developers** |
-| Yes, as evidenced by the number of implementations and positive developer feedback. |
-| **Sustainability: Energy efficiency and eco-friendly infrastructure** |
-| Yes, keys take milliseconds to create and a few hundred bytes to store. DID Documents are typically a few kilobytes in size and are easily served using standard HTTP server software. |
-| **Economic Feasibility: DIDs costs of use must be reasonable** |
-| Yes, costs are a fraction of the smallest denomination of mainstream currencies (less than `USD 0.0000004` for an ECDSA create operation and pennies (multiples of USD 0.01) per year for storage). |
-| **Legal Recognition: Cross-border frameworks for DID acceptance** |
-| Yes, supports key types approved by multiple national governments. |
-| **Revocation and Recovery: Decentralized mechanisms for key rotation and DID recovery** |
-| Revocation is supported, and recovery is a matter for the administrator of a website domain. |
-| **Emerging Markets: Offline-friendly, low-bandwidth** |
-| Not offline-friendly except through caching. Low-bandwidth friendly for simple DID Documents. |
-| **Long-lived DIDs needed for long-lived VCs** |
-| Yes, lifetimes of DIDs match the lifetimes of domains, which are counted in decades for long-lived institutions. |
-| **Low and predictable marginal cost at scale (millions of accounts)** |
-| Yes. |
-| **Ability to create and update identifiers rapidly (within seconds)** |
-| Yes, within hundreds of milliseconds for creation and for serving the file from a website domain. |
-| **Support for key rotation** |
-| Yes. |
-| **Reliable and predictable-latency operation, for updating and resolving** |
-| Yes. |
-| **Resolution should not require additional state or context** |
-| Yes. |
-| **DIDs are permanent and immutable account identifiers** |
-| Yes. |
-| **Consider support for various DID Traits: https://identity.foundation/did-traits/** |
-| BAD CRITERIA: Traits should be listed directly. |
-| **Consider categories defined by DID Rubric: https://www.w3.org/TR/did-rubric/** |
-| BAD CRITERIA: Rubric categories should be listed directly. |
-| **Who WANTS to standardize the DID method and commits to doing the work?** |
-| Digital Bazaar will commit to doing the base spec work through the entire standardization process but will rely on other teams, such as `did:webvh` to add additional features. |
-| **Are there AT LEAST two WG members who support standardization of a DID method?** |
-| Yes, Digital Bazaar and Province of BC. |
-| **Are there no trademark or IP issues?** |
-| None. |
-| **Diversity of the set of selected DID methods** |
-| BAD CRITERIA: Should be removed as this is a meta-question about the set of selected methods. |
-| **At least one ephemeral DID method** |
-| This is not an ephemeral DID Method. |
-| **At least one web-based DID method** |
-| This could be considered one of the Web-based DID Methods. |
-| **At least one fully decentralized DID method** |
-| While it is debatable that this is a fully decentralized DID Method, the reliance on DNS and the centralized hosting on a website probably disqualifies it from what people typically mean by "fully decentralized". |
+| **Criteria** | **Details** |
+|----------|----------|
+| **Alignment with DID Core specification** | Yes, fully compliant with DID specification. |
+| **Security and privacy features** | INEFFECTIVE CRITERIA: Every DID Method will probably state: Yes, has security and privacy features. |
+| **Scalability and performance** | Good scalability. Limits are tied to CPU and memory speeds (ECDSA generation: ~1,000 keys per second per core) |
+| **Ease of implementation and use** | Relatively easy to implement and use. Development effort for a single developer creating an initial implementation is one to three days. A complete production-ready implementation might take two to three weeks. |
+| **Community adoption and support** | Implemented by at least six independent software systems. |
+| **Compliance with relevant regulations and best practices** | INEFFECTIVE CRITERIA: Every DID Method will probably state: Yes, for the regulations and best practices that apply. |
+| **Global government-approved crypto** | Uses latest approved NIST and FIPS cryptography (ECDSA and EdDSA) used by many Western nation-states with ability to support cryptography backed by other Eastern nation-state governments. |
+| **Privacy-preserving crypto** | Yes, supports BBS privacy-preserving cryptographic key formats. |
+| **Digitally signed cryptographic log of changes to the DID Document** | No. |
+| **Multi-factor binding to DNS** | No. |
+| **Specification with multiple implementers** | Yes, although the specification needs further work and updating. |
+| **Scope/domain of the types of entities/subjects addressed/named by a particular method** | INEFFECTIVE CRITERIA: Debatably. Claiming that specific types of entities require specific types of DIDs seems like a privacy-harming anti-pattern. |
+| **Estimate of the daily transaction volume of each scope/domain** | INEFFECTIVE CRITERIA: Debatably. Being able to count transaction volume of DID usage seems like a privacy harming anti-pattern. Estimating without hard data seems fraught as well. It is difficult to get these sorts of counts from decentralized systems. |
+| **DID Methods that do not serve the needs of a particular company or government** | INEFFECTIVE CRITERIA: The meaning of "do not serve" is unclear. |
+| **Governance: Clear frameworks for updates, dispute resolution, and decision-making** | Framework for updates and dispute resolution is based on the domain hosting the document. Disputes regarding domain names are processed through IANA's [dispute resolution procedures](https://www.icann.org/resources/pages/help/dndr/udrp-en). |
+| **Usability: Simple implementation for developers** | Yes, as evidenced by the number of implementations and positive developer feedback. |
+| **Sustainability: Energy efficiency and eco-friendly infrastructure** | Yes, keys take milliseconds to create and a few hundred bytes to store. DID Documents are typically a few kilobytes in size and are easily served using standard HTTP server software. |
+| **Economic Feasibility: DIDs costs of use must be reasonable** | Yes, costs are a fraction of the smallest denomination of mainstream currencies (less than `USD 0.0000004` for an ECDSA create operation and pennies (multiples of USD 0.01) per year for storage). |
+| **Legal Recognition: Cross-border frameworks for DID acceptance** | Yes, supports key types approved by multiple national governments. |
+| **Revocation and Recovery: Decentralized mechanisms for key rotation and DID recovery** | Revocation is supported, and recovery is a matter for the administrator of a website domain. |
+| **Emerging Markets: Offline-friendly, low-bandwidth** | Not offline-friendly except through caching. Low-bandwidth friendly for simple DID Documents. |
+| **Long-lived DIDs needed for long-lived VCs** | Yes, lifetimes of DIDs match the lifetimes of domains, which are counted in decades for long-lived institutions. |
+| **Low and predictable marginal cost at scale (millions of accounts)** | Yes. |
+| **Ability to create and update identifiers rapidly (within seconds)** | Yes, within hundreds of milliseconds for creation and for serving the file from a website domain. |
+| **Support for key rotation** | Yes. |
+| **Reliable and predictable-latency operation, for updating and resolving** | Yes. |
+| **Resolution should not require additional state or context** | Yes. |
+| **DIDs are permanent and immutable account identifiers** | Yes. |
+| **Consider support for various DID Traits: https://identity.foundation/did-traits/** | BAD CRITERIA: Traits should be listed directly. |
+| **Consider categories defined by DID Rubric: https://www.w3.org/TR/did-rubric/** | BAD CRITERIA: Rubric categories should be listed directly. |
+| **Who WANTS to standardize the DID method and commits to doing the work?** | Digital Bazaar will commit to doing the base spec work through the entire standardization process but will rely on other teams, such as `did:webvh` to add additional features. |
+| **Are there AT LEAST two WG members who support standardization of a DID method?** | Yes, Digital Bazaar and Province of BC. |
+| **Are there no trademark or IP issues?** | None. |
+| **Diversity of the set of selected DID methods** | BAD CRITERIA: Should be removed as this is a meta-question about the set of selected methods. |
+| **At least one ephemeral DID method** | This is not an ephemeral DID Method. |
+| **At least one web-based DID method** | This could be considered one of the Web-based DID Methods. |
+| **At least one fully decentralized DID method** | While it is debatable that this is a fully decentralized DID Method, the reliance on DNS and the centralized hosting on a website probably disqualifies it from what people typically mean by "fully decentralized". |
 
 ## Supporting use cases
 

--- a/method-proposals/PROPOSAL-did-webplus.md
+++ b/method-proposals/PROPOSAL-did-webplus.md
@@ -85,10 +85,7 @@ How this DID method meets the [DID method selection criteria](../selection-crite
 | **Who WANTS to standardize the DID method and commits to doing the work?** | LedgerDomain and Open Credentialing Initiative. |
 | **Are there AT LEAST two WG members who support standardization of a DID method?** | LedgerDomain and Open Credentialing Initiative. |
 | **Are there no trademark or IP issues?** | To the best of our knowledge, `did:webplus` does not infringe upon any existing intellectual property rights, patents, or trademarks.  If any unforeseen intellectual property or trademark concerns arise, LedgerDomain is committed to addressing them transparently and in good faith.  In the event that a legitimate claim is identified, LedgerDomain will assess the matter and, where appropriate, make a voluntary donation or take other reasonable actions to ensure continued open and equitable access. |
-| **Diversity of the set of selected DID methods** | Not applicable for evaluation of a single DID method. |
-| **At least one ephemeral DID method** | `did:webplus` is not an ephemeral DID method. |
-| **At least one web-based DID method** | `did:webplus` should be considered a web-based DID method. |
-| **At least one fully decentralized DID method** | `did:webplus` should be considered as decentralized as the set of VDRs and VDGs in use, which could be structured to have any degree of decentralization.  However, it's not a "purely decentralized" DID method such as one based on a peer-to-peer network. |
+| **What type of DID method is this?** | Web-based. `did:webplus` should also be considered as decentralized as the set of VDRs and VDGs in use, which could be structured to have any degree of decentralization.  However, it's not a "purely decentralized" DID method such as one based on a peer-to-peer network. |
 
 ## Supporting Use Cases
 

--- a/method-proposals/PROPOSAL-did-webs.md
+++ b/method-proposals/PROPOSAL-did-webs.md
@@ -50,10 +50,7 @@ Documenting how this DID method meets the [DID method selection criteria](../sel
 | **Support for standardization by interested parties** | ToIP, GLEIF, and other private entities are committed to standardization. Financial subsidies are likely. |
 | **Support from at least two WG members** | Yes. |
 | **No trademark or IP issues** | None. |
-| **Diversity of selected DID methods** | N/A. |
-| **Ephemeral DID method** | Yes. |
-| **Web-based DID method** | Yes. |
-| **Fully decentralized DID method** | No. |
+| **What type of DID method is this?** | Ephemeral, Web-based |
 
 ## Supporting Use Cases
 

--- a/method-proposals/PROPOSAL-did-webvh.md
+++ b/method-proposals/PROPOSAL-did-webvh.md
@@ -61,82 +61,45 @@ method that complement `did:web` include:
 
 Document here how this DID method meets the [DID method selection criteria](../selection-criteria/).
 
-| **Criteria** |
-| -------- |
-| **Alignment with DID Core specification** |
-| Yes, fully compliant with DID specification. |
-| **Security and privacy features** |
-| Yes, the DID Method has security and privacy features. |
-| **Scalability and performance** |
-| Good scalability. Limits are tied to CPU and memory speeds (ECDSA generation: ~1,000 keys per second per core) |
-| **Ease of implementation and use** |
-| Relatively easy to implement and use. Registrar and resolver implementations are about ~2k lines of code. Web server development effort for a single developer creating an initial implementation is one to three weeks. A complete production-ready web server implementation might take one to two months from scratch, driven by the desired governance around the publication of DIDs and related resources.  |
-| **Community adoption and support** |
-| Implemented by at least four independent software systems. |
-| **Compliance with relevant regulations and best practices** |
-| Yes. |
-| **Global government-approved crypto** |
-| The DID Method itself uses the latest approved NIST and FIPS cryptography (ECDSA and EdDSA) used by many Western nation-states with ability to support cryptography backed by other Eastern nation-state governments. The DID Method is defined to support evolving the cryptography used by the DID Method through the versioning of the specification and DIDs using the specification. DIDs created by DID Controllers can use whatever cryptography they want -- the specification does not constrain what is put into the DIDDoc. |
-| **Privacy-preserving crypto** |
-| Yes, supports BBS privacy-preserving cryptographic key formats within the DIDDoc. Any DID-Core compatible key formats can be defined in the published DIDDocs. |
-| **Digitally signed cryptographic log of changes to the DID Document** |
-| Yes. |
-| **Multi-factor binding to DNS** |
-| No. |
-| **Specification with multiple implementers** |
-| Yes. The specification editors/authors agree we are nearing a 1.0 version. |
-| **Scope/domain of the types of entities/subjects addressed/named by a particular method** |
-| Expected to be used primarily for organizational entities, but that is not limited by the specification. Self-hosting is possible, and one could imagine DID-hosting services could be created. |
-| **Estimate of the daily transaction volume of each scope/domain** |
-| A difficult metric, but "web-scale" seems the appropriate response. The publication and resolution process is comparable to writing/retrieving a file from a web server. |
-| **DID Methods that do not serve the needs of a particular company or government** |
-| The DID Method and publication/retrieval methods are independent of any particular entity. Requires only the ability to publish and update a web file. |
-| **Governance: Clear frameworks for updates, dispute resolution, and decision-making** |
-| Framework for updates and dispute resolution is based on the domain or platform hosting the document. Disputes regarding domain names are processed through IANA's [dispute resolution procedures](https://www.icann.org/resources/pages/help/dndr/udrp-en). `did:webvh` DID Logs published to a platform (such as GitHub, or a DID publishing service) would be subject to the dispute resolution governance of the selected platform or service. |
-| **Usability: Simple implementation for developers** |
-| Yes, as evidenced by the number of early implementations and positive developer feedback. |
-| **Sustainability: Energy efficiency and eco-friendly infrastructure** |
-| Yes, keys take milliseconds to create and minimal overhead to store. `did:webvh` DID Logs are typically a few kilobytes in size and are easily served using standard HTTP server software. Frequently updated, very long lasting `did:webvh` DIDs might have a DID Log in the low megabyte size. The majority  of the DID Log is each version of the DIDDoc. |
-| **Economic Feasibility: DIDs costs of use must be reasonable** |
-| Yes, costs are a fraction of the smallest denomination of mainstream currencies (less than `USD 0.0000004` for an ECDSA create operation and pennies (multiples of USD 0.01) per year for storage). |
-| **Legal Recognition: Cross-border frameworks for DID acceptance** |
-| Yes, supports key types approved by multiple national governments. |
-| **Revocation and Recovery: Decentralized mechanisms for key rotation and DID recovery** |
-| Key rotation is inherent in the DID Method and is secure and verifiable, independent of DNS. Revocation is supported per the DID-Core specification. Recovery is both a matter for the administrator of a website domain, and how the DID Controller manages the `did:webvh` update authorization keys. For example, a `did:webvh` could retain an offline key that is used for DID recovery, should that be needed. |
-| **Emerging Markets: Offline-friendly, low-bandwidth** |
-| Not offline-friendly except through caching. Low-bandwidth friendly for simple DID Documents. The `did:webvh` log format use of [JSON Lines](https://jsonlines.org) enables retrieval of only added versions (log entries) using standard HTTP headers.  |
-| **Long-lived DIDs needed for long-lived VCs** |
-| Yes, lifetimes of DIDs match the lifetimes of domains, which are counted in decades for long-lived institutions. The formal use of DID Method specification versions enables evolving the characteristics of the DID Method (e.g., permitted hashing and signature algorithms) over the lifetime of the DID. The DID Controller has full control over the contents of the DIDDoc versions, allowing updates to the DID as the DID Core specification evolves, and as cryptographic requirements change. The optional portability mechanism allows for DIDs to be moved to a new location (ideally with an HTTPS "redirect"), while retaining it's self-certifying identifier and verifiable history. The inclusion of the globally unique self-certifying identifier in the DID allows for services such as trust registries and DID stores to retain verifiable copies of the DID to extend their lifetimes. |
-| **Low and predictable marginal cost at scale (millions of accounts)** |
-| Yes -- "web-scale". |
-| **Ability to create and update identifiers rapidly (within seconds)** |
-| Yes, within hundreds of milliseconds for creation and for serving the DID Log file from a website domain. |
-| **Support for key rotation** |
-| Yes, with a verifiable history of the versions of the DID, past keys and rotations. |
-| **Reliable and predictable-latency operation, for updating and resolving** |
-| Yes. |
-| **Resolution should not require additional state or context** |
-| Yes. |
-| **DIDs are permanent and immutable account identifiers** |
-| Yes. Optionally, a DID **MAY** enable portability, where the location of the DID can change (ideally with an HTTPS redirection), while retaining the same immutable self-certifying ID (SCID) and the same verifiable history -- including the verifiable change of the DID's web location.  |
-| **Consider support for various DID Traits: https://identity.foundation/did-traits/** |
-| TBD. |
-| **Consider categories defined by DID Rubric: https://www.w3.org/TR/did-rubric/** |
-| TBD. |
-| **Who WANTS to standardize the DID method and commits to doing the work?** |
-| BC Gov is willing to continue its work on the base spec and implementations. |
-| **Are there AT LEAST two WG members who support standardization of a DID method?** |
-| Yes, Digital Bazaar and Province of BC. |
-| **Are there no trademark or IP issues?** |
-| None. |
-| **Diversity of the set of selected DID methods** |
-| Unsure how to answer |
-| **At least one ephemeral DID method** |
-| This is not an ephemeral DID Method. |
-| **At least one web-based DID method** |
-| This could be considered one of the Web-based DID Methods. |
-| **At least one fully decentralized DID method** |
-| This is arguably a fully decentralized DID Method. While there is reliance on DNS to locate the DID Log, the DID, its self-certifying identifier and its history chained and fully verifiable. Optionally, the DID can be "witnessed" to add verifications of DID updates by outside parties. Even if the DIDDoc is found elsewhere (such as in a Trust Registry or DID archive) it can be verified across versions. |
+| **Criteria** | **Details** |
+|----------|----------|
+| **Alignment with DID Core specification** | Yes, fully compliant with DID specification. |
+| **Security and privacy features** | Yes, the DID Method has security and privacy features. |
+| **Scalability and performance** | Good scalability. Limits are tied to CPU and memory speeds (ECDSA generation: ~1,000 keys per second per core) |
+| **Ease of implementation and use** | Relatively easy to implement and use. Registrar and resolver implementations are about ~2k lines of code. Web server development effort for a single developer creating an initial implementation is one to three weeks. A complete production-ready web server implementation might take one to two months from scratch, driven by the desired governance around the publication of DIDs and related resources.  |
+| **Community adoption and support** | Implemented by at least four independent software systems. |
+| **Compliance with relevant regulations and best practices** | Yes. |
+| **Global government-approved crypto** | The DID Method itself uses the latest approved NIST and FIPS cryptography (ECDSA and EdDSA) used by many Western nation-states with ability to support cryptography backed by other Eastern nation-state governments. The DID Method is defined to support evolving the cryptography used by the DID Method through the versioning of the specification and DIDs using the specification. DIDs created by DID Controllers can use whatever cryptography they want -- the specification does not constrain what is put into the DIDDoc. |
+| **Privacy-preserving crypto** | Yes, supports BBS privacy-preserving cryptographic key formats within the DIDDoc. Any DID-Core compatible key formats can be defined in the published DIDDocs. |
+| **Digitally signed cryptographic log of changes to the DID Document** | Yes. |
+| **Multi-factor binding to DNS** | No. |
+| **Specification with multiple implementers** | Yes. The specification editors/authors agree we are nearing a 1.0 version. |
+| **Scope/domain of the types of entities/subjects addressed/named by a particular method** | Expected to be used primarily for organizational entities, but that is not limited by the specification. Self-hosting is possible, and one could imagine DID-hosting services could be created. |
+| **Estimate of the daily transaction volume of each scope/domain** | A difficult metric, but "web-scale" seems the appropriate response. The publication and resolution process is comparable to writing/retrieving a file from a web server. |
+| **DID Methods that do not serve the needs of a particular company or government** | The DID Method and publication/retrieval methods are independent of any particular entity. Requires only the ability to publish and update a web file. |
+| **Governance: Clear frameworks for updates, dispute resolution, and decision-making** | Framework for updates and dispute resolution is based on the domain or platform hosting the document. Disputes regarding domain names are processed through IANA's [dispute resolution procedures](https://www.icann.org/resources/pages/help/dndr/udrp-en). `did:webvh` DID Logs published to a platform (such as GitHub, or a DID publishing service) would be subject to the dispute resolution governance of the selected platform or service. |
+| **Usability: Simple implementation for developers** | Yes, as evidenced by the number of early implementations and positive developer feedback. |
+| **Sustainability: Energy efficiency and eco-friendly infrastructure** | Yes, keys take milliseconds to create and minimal overhead to store. `did:webvh` DID Logs are typically a few kilobytes in size and are easily served using standard HTTP server software. Frequently updated, very long lasting `did:webvh` DIDs might have a DID Log in the low megabyte size. The majority  of the DID Log is each version of the DIDDoc. |
+| **Economic Feasibility: DIDs costs of use must be reasonable** | Yes, costs are a fraction of the smallest denomination of mainstream currencies (less than `USD 0.0000004` for an ECDSA create operation and pennies (multiples of USD 0.01) per year for storage). |
+| **Legal Recognition: Cross-border frameworks for DID acceptance** | Yes, supports key types approved by multiple national governments. |
+| **Revocation and Recovery: Decentralized mechanisms for key rotation and DID recovery** | Key rotation is inherent in the DID Method and is secure and verifiable, independent of DNS. Revocation is supported per the DID-Core specification. Recovery is both a matter for the administrator of a website domain, and how the DID Controller manages the `did:webvh` update authorization keys. For example, a `did:webvh` could retain an offline key that is used for DID recovery, should that be needed. |
+| **Emerging Markets: Offline-friendly, low-bandwidth** | Not offline-friendly except through caching. Low-bandwidth friendly for simple DID Documents. The `did:webvh` log format use of [JSON Lines](https://jsonlines.org) enables retrieval of only added versions (log entries) using standard HTTP headers.  |
+| **Long-lived DIDs needed for long-lived VCs** | Yes, lifetimes of DIDs match the lifetimes of domains, which are counted in decades for long-lived institutions. The formal use of DID Method specification versions enables evolving the characteristics of the DID Method (e.g., permitted hashing and signature algorithms) over the lifetime of the DID. The DID Controller has full control over the contents of the DIDDoc versions, allowing updates to the DID as the DID Core specification evolves, and as cryptographic requirements change. The optional portability mechanism allows for DIDs to be moved to a new location (ideally with an HTTPS "redirect"), while retaining it's self-certifying identifier and verifiable history. The inclusion of the globally unique self-certifying identifier in the DID allows for services such as trust registries and DID stores to retain verifiable copies of the DID to extend their lifetimes. |
+| **Low and predictable marginal cost at scale (millions of accounts)** | Yes -- "web-scale". |
+| **Ability to create and update identifiers rapidly (within seconds)** | Yes, within hundreds of milliseconds for creation and for serving the DID Log file from a website domain. |
+| **Support for key rotation** | Yes, with a verifiable history of the versions of the DID, past keys and rotations. |
+| **Reliable and predictable-latency operation, for updating and resolving** | Yes. |
+| **Resolution should not require additional state or context** | Yes. |
+| **DIDs are permanent and immutable account identifiers** | Yes. Optionally, a DID **MAY** enable portability, where the location of the DID can change (ideally with an HTTPS redirection), while retaining the same immutable self-certifying ID (SCID) and the same verifiable history -- including the verifiable change of the DID's web location.  |
+| **Consider support for various DID Traits: https://identity.foundation/did-traits/** | TBD. |
+| **Consider categories defined by DID Rubric: https://www.w3.org/TR/did-rubric/** | TBD. |
+| **Who WANTS to standardize the DID method and commits to doing the work?** | BC Gov is willing to continue its work on the base spec and implementations. |
+| **Are there AT LEAST two WG members who support standardization of a DID method?** | Yes, Digital Bazaar and Province of BC. |
+| **Are there no trademark or IP issues?** | None. |
+| **Diversity of the set of selected DID methods** | Unsure how to answer |
+| **At least one ephemeral DID method** | This is not an ephemeral DID Method. |
+| **At least one web-based DID method** | This could be considered one of the Web-based DID Methods. |
+| **At least one fully decentralized DID method** | This is arguably a fully decentralized DID Method. While there is reliance on DNS to locate the DID Log, the DID, its self-certifying identifier and its history chained and fully verifiable. Optionally, the DID can be "witnessed" to add verifications of DID updates by outside parties. Even if the DIDDoc is found elsewhere (such as in a Trust Registry or DID archive) it can be verified across versions. |
 
 ## Supporting use cases
 

--- a/method-proposals/PROPOSAL-did-webvh.md
+++ b/method-proposals/PROPOSAL-did-webvh.md
@@ -96,10 +96,7 @@ Document here how this DID method meets the [DID method selection criteria](../s
 | **Who WANTS to standardize the DID method and commits to doing the work?** | BC Gov is willing to continue its work on the base spec and implementations. |
 | **Are there AT LEAST two WG members who support standardization of a DID method?** | Yes, Digital Bazaar and Province of BC. |
 | **Are there no trademark or IP issues?** | None. |
-| **Diversity of the set of selected DID methods** | Unsure how to answer |
-| **At least one ephemeral DID method** | This is not an ephemeral DID Method. |
-| **At least one web-based DID method** | This could be considered one of the Web-based DID Methods. |
-| **At least one fully decentralized DID method** | This is arguably a fully decentralized DID Method. While there is reliance on DNS to locate the DID Log, the DID, its self-certifying identifier and its history chained and fully verifiable. Optionally, the DID can be "witnessed" to add verifications of DID updates by outside parties. Even if the DIDDoc is found elsewhere (such as in a Trust Registry or DID archive) it can be verified across versions. |
+| **What type of DID method is this?** | Web-based, Decentralized. This is arguably a fully decentralized DID Method. While there is reliance on DNS to locate the DID Log, the DID, its self-certifying identifier and its history chained and fully verifiable. Optionally, the DID can be "witnessed" to add verifications of DID updates by outside parties. Even if the DIDDoc is found elsewhere (such as in a Trust Registry or DID archive) it can be verified across versions. |
 
 ## Supporting use cases
 


### PR DESCRIPTION
Currently, the table formatting for proposals is inconsistent: some use a 1-column style, others use a 2-column style. The 2-column style is more readable, as it more consistently separates the questions vs the answers, without relying on visual flair such as **bold**.

I'm setting this PR to draft, as I reckon #43 is a precursor to this as it combines the redundant questions at the bottom into a single question (see that PR for details). If #43 is approved, I can reformat this PR to reflect that change in the tables.

No substantial change to content has been made, only the form of the tables (and a few minor typos, e.g., lots of uses of "Unkown" which seems to be a mistake.)