### PR TITLE
Add SC approval and report step to DIF recommended

### DIFF
--- a/dif-recommended/README.md
+++ b/dif-recommended/README.md
@@ -4,7 +4,7 @@ This page describes a process for DID methods to achieve a status of "DIF-recomm
 
 The process is as follows:
 
-1. The method advocate submits the DID method for consideration following [the documented procedure](https://github.com/decentralized-identity/did-methods/blob/main/method-proposals/README.md).
+1. The method advocate submits the DID method for consideration by creating a Pull Request with a [DID method recommendation proposals](https://github.com/decentralized-identity/did-methods/blob/main/method-proposals/). The proposed DID method may or may not be a DIF work item (in the latter case, the usual [Work Item Life Cycle](https://github.com/decentralized-identity/org/blob/main/work-item-lifecycle.md) applies).
 1. The advocate presents the proposal template contents during a working group meeting and receives initial feedback.
 1. When the method meets the criteria outlined in the table below, the advocate schedules the first deep dive with the working group chairs during a regular meeting.
 1. The first deep dive occurs, where the group provides detailed feedback on the method's maturity and compliance with requirements.
@@ -13,6 +13,8 @@ The process is as follows:
 1. After the second deep dive, the working group chairs submit a PR changing the table's last column from 'no' to 'yes', signaling the start of the formal review period.
 1. The 60-day formal review period begins immediately after the second deep dive and is announced publicly via relevant DIF mailing lists.
 1. During the formal review period, all questions or concerns must be addressed through PR comments. Active discussion is expected for each method.
+1. During the formal review period, the DIF Steering Committee can meet and approve or reject the DIF Recommended Status. If the DIF Steering Committee does not meet in this period, it is considered to have approved the status.
+1. During the formal review period, the DID Methods WG produces a report which summarizes the steps that have been taken in this process, as documentation for justifying the DIF Recommended Status.
 1. If no outstanding questions, concerns, or objections remain at the end of the formal review period, the chairs merge the PR and the method attains DIF Recommended Status.
 
 The following table tracks DID methods that are currently participating in this process.


### PR DESCRIPTION
This adds two steps to the DIF recommended process:
- DIF Steering Committee approval
- A report about the process at the end